### PR TITLE
Implement counter events as a metric instead of a log event

### DIFF
--- a/src/stackdriver-nozzle/mocks/logger.go
+++ b/src/stackdriver-nozzle/mocks/logger.go
@@ -1,0 +1,62 @@
+package mocks
+
+import "github.com/cloudfoundry/lager"
+
+type MockLogger struct {
+	logs []Log
+}
+
+type Log struct {
+	Level  lager.LogLevel
+	Action string
+	Err    error
+	Datas  []lager.Data
+}
+
+func (m *MockLogger) RegisterSink(lager.Sink) {
+	panic("NYI")
+}
+
+func (m *MockLogger) Session(task string, data ...lager.Data) lager.Logger {
+	panic("NYI")
+}
+
+func (m *MockLogger) SessionName() string {
+	panic("NYI")
+}
+
+func (m *MockLogger) Debug(action string, data ...lager.Data) {
+	panic("NYI")
+}
+
+func (m *MockLogger) Info(action string, data ...lager.Data) {
+	m.logs = append(m.logs, Log{
+		Level:  lager.INFO,
+		Action: action,
+		Datas:  data,
+	})
+}
+
+func (m *MockLogger) Error(action string, err error, data ...lager.Data) {
+	m.logs = append(m.logs, Log{
+		Level:  lager.ERROR,
+		Action: action,
+		Err:    err,
+		Datas:  data,
+	})
+}
+
+func (m *MockLogger) Fatal(action string, err error, data ...lager.Data) {
+	panic("NYI")
+}
+
+func (m *MockLogger) WithData(lager.Data) lager.Logger {
+	panic("NYI")
+}
+
+func (m *MockLogger) LastLog() Log {
+	if len(m.logs) == 0 {
+		return Log{}
+	}
+	return m.logs[len(m.logs)-1]
+}

--- a/src/stackdriver-nozzle/mocks/serializer.go
+++ b/src/stackdriver-nozzle/mocks/serializer.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"github.com/cloudfoundry/sonde-go/events"
+	"stackdriver-nozzle/serializer"
+)
+
+type MockSerializer struct {
+	GetLogFn     func(*events.Envelope) *serializer.Log
+	GetMetricsFn func(*events.Envelope) ([]*serializer.Metric, error)
+	IsLogFn      func(*events.Envelope) bool
+}
+
+func (m *MockSerializer) GetLog(envelope *events.Envelope) *serializer.Log {
+	if m.GetLogFn != nil {
+		return m.GetLogFn(envelope)
+	}
+	return nil
+}
+
+func (m *MockSerializer) GetMetrics(envelope *events.Envelope) ([]*serializer.Metric, error) {
+	if m.GetMetricsFn != nil {
+		return m.GetMetricsFn(envelope)
+	}
+	return nil, nil
+}
+
+func (m *MockSerializer) IsLog(envelope *events.Envelope) bool {
+	if m.IsLogFn != nil {
+		return m.IsLogFn(envelope)
+	}
+	return true
+}

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -34,7 +34,7 @@ func (n *Nozzle) HandleEvent(envelope *events.Envelope) error {
 		n.StackdriverClient.PostLog(log.Payload, log.Labels)
 		return nil
 	} else {
-		metrics := n.Serializer.GetMetrics(envelope)
+		metrics, _ := n.Serializer.GetMetrics(envelope)
 		return n.postMetrics(metrics)
 	}
 }

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -34,7 +34,10 @@ func (n *Nozzle) HandleEvent(envelope *events.Envelope) error {
 		n.StackdriverClient.PostLog(log.Payload, log.Labels)
 		return nil
 	} else {
-		metrics, _ := n.Serializer.GetMetrics(envelope)
+		metrics, err := n.Serializer.GetMetrics(envelope)
+		if err != nil {
+			return err
+		}
 		return n.postMetrics(metrics)
 	}
 }

--- a/src/stackdriver-nozzle/serializer/serializer.go
+++ b/src/stackdriver-nozzle/serializer/serializer.go
@@ -47,15 +47,16 @@ func (s *cachingClientSerializer) GetLog(e *events.Envelope) *Log {
 }
 
 func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metric {
+	labels := s.buildLabels(envelope)
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
+		valueMetric := envelope.GetValueMetric()
 		return []*Metric{{
-			Name:   envelope.GetValueMetric().GetName(),
-			Value:  envelope.GetValueMetric().GetValue(),
-			Labels: s.buildLabels(envelope)}}
+			Name:   valueMetric.GetName(),
+			Value:  valueMetric.GetValue(),
+			Labels: labels}}
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
-		labels := s.buildLabels(envelope)
 		return []*Metric{
 			{"diskBytesQuota", float64(containerMetric.GetDiskBytesQuota()), labels},
 			{"instanceIndex", float64(containerMetric.GetInstanceIndex()), labels},
@@ -64,6 +65,13 @@ func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metri
 			{"memoryBytes", float64(containerMetric.GetMemoryBytes()), labels},
 			{"memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), labels},
 		}
+	case events.Envelope_CounterEvent:
+		counterEvent := envelope.GetCounterEvent()
+		return []*Metric{{
+			Name:   counterEvent.GetName(),
+			Value:  float64(counterEvent.GetTotal()),
+			Labels: labels,
+		}}
 	default:
 		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
 		return nil
@@ -75,11 +83,8 @@ func (s *cachingClientSerializer) IsLog(envelope *events.Envelope) bool {
 	switch *envelope.EventType {
 	case events.Envelope_HttpStartStop, events.Envelope_LogMessage, events.Envelope_Error:
 		return true
-	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric:
+	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric, events.Envelope_CounterEvent:
 		return false
-	case events.Envelope_CounterEvent:
-		//Not yet implemented as a metric
-		return true
 	default:
 		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
 		return false

--- a/src/stackdriver-nozzle/serializer/serializer.go
+++ b/src/stackdriver-nozzle/serializer/serializer.go
@@ -23,7 +23,7 @@ type Log struct {
 
 type Serializer interface {
 	GetLog(*events.Envelope) *Log
-	GetMetrics(*events.Envelope) []*Metric
+	GetMetrics(*events.Envelope) ([]*Metric, error)
 	IsLog(*events.Envelope) bool
 }
 
@@ -46,7 +46,7 @@ func (s *cachingClientSerializer) GetLog(e *events.Envelope) *Log {
 	return &Log{Payload: e, Labels: s.buildLabels(e)}
 }
 
-func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metric {
+func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) ([]*Metric, error) {
 	labels := s.buildLabels(envelope)
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
@@ -54,7 +54,7 @@ func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metri
 		return []*Metric{{
 			Name:   valueMetric.GetName(),
 			Value:  valueMetric.GetValue(),
-			Labels: labels}}
+			Labels: labels}}, nil
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
 		return []*Metric{
@@ -64,30 +64,26 @@ func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metri
 			{"diskBytes", float64(containerMetric.GetDiskBytes()), labels},
 			{"memoryBytes", float64(containerMetric.GetMemoryBytes()), labels},
 			{"memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), labels},
-		}
+		}, nil
 	case events.Envelope_CounterEvent:
 		counterEvent := envelope.GetCounterEvent()
 		return []*Metric{{
 			Name:   counterEvent.GetName(),
 			Value:  float64(counterEvent.GetTotal()),
 			Labels: labels,
-		}}
+		}}, nil
 	default:
-		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
-		return nil
+		return nil, fmt.Errorf("unknown event type: %v", envelope.EventType)
 	}
 
 }
 
 func (s *cachingClientSerializer) IsLog(envelope *events.Envelope) bool {
 	switch *envelope.EventType {
-	case events.Envelope_HttpStartStop, events.Envelope_LogMessage, events.Envelope_Error:
-		return true
 	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric, events.Envelope_CounterEvent:
 		return false
 	default:
-		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
-		return false
+		return true
 	}
 }
 

--- a/src/stackdriver-nozzle/serializer/serializer_test.go
+++ b/src/stackdriver-nozzle/serializer/serializer_test.go
@@ -129,6 +129,29 @@ var _ = Describe("Serializer", func() {
 			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytes", float64(16601088), labels}))
 			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytesQuota", float64(33554432), labels}))
 		})
+
+		It("creates metric for CounterEvent", func() {
+			eventType := events.Envelope_CounterEvent
+			name := "counterName"
+			total := uint64(123456)
+
+			event := events.CounterEvent{
+				Name:  &name,
+				Total: &total,
+			}
+			envelope := &events.Envelope{
+				EventType:    &eventType,
+				CounterEvent: &event,
+			}
+
+			labels := map[string]string{
+				"eventType": "CounterEvent",
+			}
+
+			metrics := subject.GetMetrics(envelope)
+			Expect(metrics).To(HaveLen(1))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), labels}))
+		})
 	})
 
 	Context("isLog", func() {
@@ -159,7 +182,7 @@ var _ = Describe("Serializer", func() {
 			Expect(subject.IsLog(envelope)).To(BeFalse())
 		})
 
-		XIt("CounterEvent is *NOT* log", func() {
+		It("CounterEvent is *NOT* log", func() {
 			eventType := events.Envelope_CounterEvent
 
 			envelope := &events.Envelope{
@@ -253,8 +276,21 @@ var _ = Describe("Serializer", func() {
 
 			})
 
-			XIt("CounterEvent does not add app id", func() {
-				//TODO
+			It("CounterEvent does not add app id", func() {
+				eventType := events.Envelope_CounterEvent
+
+				event := events.CounterEvent{}
+				envelope := &events.Envelope{
+					EventType:    &eventType,
+					CounterEvent: &event,
+				}
+				metrics := subject.GetMetrics(envelope)
+
+				Expect(metrics).To(HaveLen(1))
+				valueMetric := metrics[0]
+
+				labels := valueMetric.Labels
+				Expect(labels).NotTo(HaveKey("applicationId"))
 			})
 
 			It("Error does not add app id", func() {


### PR DESCRIPTION
Counter events will now be sent to stack driver as metrics instead of logs.

Note that we are using the "total" value of the metric instead of the "delta". 
This might need to be revisited at a later point. I think total is fine for MVP. 