### PR TITLE
Use the timestamp in  the firehose envelope instead of current time for metrics

### DIFF
--- a/src/stackdriver-nozzle/mocks/serializer.go
+++ b/src/stackdriver-nozzle/mocks/serializer.go
@@ -1,24 +1,25 @@
 package mocks
 
 import (
+	"cloud.google.com/go/logging"
 	"github.com/cloudfoundry/sonde-go/events"
-	"stackdriver-nozzle/serializer"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
 type MockSerializer struct {
-	GetLogFn     func(*events.Envelope) *serializer.Log
-	GetMetricsFn func(*events.Envelope) ([]*serializer.Metric, error)
+	GetLogFn     func(*events.Envelope) *logging.Entry
+	GetMetricsFn func(*events.Envelope) ([]*monitoringpb.CreateTimeSeriesRequest, error)
 	IsLogFn      func(*events.Envelope) bool
 }
 
-func (m *MockSerializer) GetLog(envelope *events.Envelope) *serializer.Log {
+func (m *MockSerializer) GetLog(envelope *events.Envelope) *logging.Entry {
 	if m.GetLogFn != nil {
 		return m.GetLogFn(envelope)
 	}
 	return nil
 }
 
-func (m *MockSerializer) GetMetrics(envelope *events.Envelope) ([]*serializer.Metric, error) {
+func (m *MockSerializer) GetMetrics(envelope *events.Envelope) ([]*monitoringpb.CreateTimeSeriesRequest, error) {
 	if m.GetMetricsFn != nil {
 		return m.GetMetricsFn(envelope)
 	}

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -43,7 +43,7 @@ func (n *Nozzle) postMetrics(metrics []*serializer.Metric) error {
 	errorsCh := make(chan error)
 
 	for _, metric := range metrics {
-		n.postMetric(errorsCh, metric.Name, metric.Value, metric.Labels)
+		n.postMetric(errorsCh, metric.Name, metric.Value, metric.EventTime, metric.Labels)
 	}
 
 	errors := []error{}
@@ -63,9 +63,9 @@ func (n *Nozzle) postMetrics(metrics []*serializer.Metric) error {
 	}
 }
 
-func (n *Nozzle) postMetric(errorsCh chan error, name string, value float64, labels map[string]string) {
+func (n *Nozzle) postMetric(errorsCh chan error, name string, value float64, eventTime int64, labels map[string]string) {
 	go func() {
-		err := n.StackdriverClient.PostMetric(name, value, labels)
+		err := n.StackdriverClient.PostMetric(name, value, eventTime, labels)
 		if err != nil {
 			errorsCh <- fmt.Errorf("name: %v value: %f, error: %v", name, value, err.Error())
 		} else {

--- a/src/stackdriver-nozzle/serializer/serializer.go
+++ b/src/stackdriver-nozzle/serializer/serializer.go
@@ -47,15 +47,16 @@ func (s *cachingClientSerializer) GetLog(e *events.Envelope) *Log {
 }
 
 func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metric {
+	labels := s.buildLabels(envelope)
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
+		valueMetric := envelope.GetValueMetric()
 		return []*Metric{{
-			Name:   envelope.GetValueMetric().GetName(),
-			Value:  envelope.GetValueMetric().GetValue(),
-			Labels: s.buildLabels(envelope)}}
+			Name:   valueMetric.GetName(),
+			Value:  valueMetric.GetValue(),
+			Labels: labels}}
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
-		labels := s.buildLabels(envelope)
 		return []*Metric{
 			{"diskBytesQuota", float64(containerMetric.GetDiskBytesQuota()), labels},
 			{"instanceIndex", float64(containerMetric.GetInstanceIndex()), labels},
@@ -64,6 +65,13 @@ func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) []*Metri
 			{"memoryBytes", float64(containerMetric.GetMemoryBytes()), labels},
 			{"memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), labels},
 		}
+	case events.Envelope_CounterEvent:
+		counterEvent := envelope.GetCounterEvent()
+		return []*Metric{{
+			Name:   counterEvent.GetName(),
+			Value:  float64(counterEvent.GetTotal()),
+			Labels: labels,
+		}}
 	default:
 		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
 		return nil
@@ -75,11 +83,8 @@ func (s *cachingClientSerializer) IsLog(envelope *events.Envelope) bool {
 	switch *envelope.EventType {
 	case events.Envelope_HttpStartStop, events.Envelope_LogMessage, events.Envelope_Error:
 		return true
-	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric:
+	case events.Envelope_ValueMetric, events.Envelope_ContainerMetric, events.Envelope_CounterEvent:
 		return false
-	case events.Envelope_CounterEvent:
-		//Not yet implemented as a metric
-		return true
 	default:
 		s.logger.Error("unknownEventType", fmt.Errorf("unknown event type: %v", envelope.EventType))
 		return false

--- a/src/stackdriver-nozzle/serializer/serializer.go
+++ b/src/stackdriver-nozzle/serializer/serializer.go
@@ -3,28 +3,21 @@ package serializer
 import (
 	"fmt"
 
+	"cloud.google.com/go/logging"
 	"errors"
 	"github.com/cloudfoundry-community/firehose-to-syslog/caching"
 	"github.com/cloudfoundry-community/firehose-to-syslog/utils"
 	"github.com/cloudfoundry/lager"
 	"github.com/cloudfoundry/sonde-go/events"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/genproto/googleapis/api/metric"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"path"
 )
 
-type Metric struct {
-	Name      string
-	Value     float64
-	EventTime int64
-	Labels    map[string]string
-}
-
-type Log struct {
-	Payload interface{}
-	Labels  map[string]string
-}
-
 type Serializer interface {
-	GetLog(*events.Envelope) *Log
-	GetMetrics(*events.Envelope) ([]*Metric, error)
+	GetLog(*events.Envelope) *logging.Entry
+	GetMetrics(*events.Envelope) ([]*monitoringpb.CreateTimeSeriesRequest, error)
 	IsLog(*events.Envelope) bool
 }
 
@@ -43,40 +36,88 @@ func NewSerializer(cachingClient caching.Caching, logger lager.Logger) Serialize
 	return &cachingClientSerializer{cachingClient, logger}
 }
 
-func (s *cachingClientSerializer) GetLog(e *events.Envelope) *Log {
-	return &Log{Payload: e, Labels: s.buildLabels(e)}
+func (s *cachingClientSerializer) GetLog(e *events.Envelope) *logging.Entry {
+	return &logging.Entry{
+		Payload: e,
+		Labels:  s.buildLabels(e),
+	}
 }
 
-func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) ([]*Metric, error) {
+func (s *cachingClientSerializer) buildTimeSeriesRequest(projectID string, name string, value float64, eventTime int64, labels map[string]string) *monitoringpb.CreateTimeSeriesRequest {
+	projectName := fmt.Sprintf("projects/%s", projectID)
+	metricType := path.Join("custom.googleapis.com", name)
+
+	return &monitoringpb.CreateTimeSeriesRequest{
+		Name: projectName,
+		TimeSeries: []*monitoringpb.TimeSeries{
+			{
+				Metric: &google_api.Metric{
+					Type:   metricType,
+					Labels: labels,
+				},
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							EndTime: &timestamp.Timestamp{
+								Seconds: eventTime,
+							},
+							StartTime: &timestamp.Timestamp{
+								Seconds: eventTime,
+							},
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_DoubleValue{
+								DoubleValue: value,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *cachingClientSerializer) GetMetrics(envelope *events.Envelope) ([]*monitoringpb.CreateTimeSeriesRequest, error) {
 	labels := s.buildLabels(envelope)
 	eventTime := envelope.GetTimestamp()
 
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
 		valueMetric := envelope.GetValueMetric()
-		return []*Metric{{
-			Name:      valueMetric.GetName(),
-			Value:     valueMetric.GetValue(),
-			EventTime: eventTime,
-			Labels:    labels}}, nil
+		return []*monitoringpb.CreateTimeSeriesRequest{
+			s.buildTimeSeriesRequest(
+				"todo", valueMetric.GetName(), valueMetric.GetValue(), eventTime, labels,
+			),
+		}, nil
 	case events.Envelope_ContainerMetric:
 		containerMetric := envelope.GetContainerMetric()
-		return []*Metric{
-			{"diskBytesQuota", float64(containerMetric.GetDiskBytesQuota()), eventTime, labels},
-			{"instanceIndex", float64(containerMetric.GetInstanceIndex()), eventTime, labels},
-			{"cpuPercentage", float64(containerMetric.GetCpuPercentage()), eventTime, labels},
-			{"diskBytes", float64(containerMetric.GetDiskBytes()), eventTime, labels},
-			{"memoryBytes", float64(containerMetric.GetMemoryBytes()), eventTime, labels},
-			{"memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), eventTime, labels},
+		return []*monitoringpb.CreateTimeSeriesRequest{
+			s.buildTimeSeriesRequest(
+				"todo", "diskBytesQuota", float64(containerMetric.GetDiskBytesQuota()), eventTime, labels,
+			),
+			s.buildTimeSeriesRequest(
+				"todo", "instanceIndex", float64(containerMetric.GetInstanceIndex()), eventTime, labels,
+			),
+			s.buildTimeSeriesRequest(
+				"todo", "cpuPercentage", float64(containerMetric.GetCpuPercentage()), eventTime, labels,
+			),
+			s.buildTimeSeriesRequest(
+				"todo", "diskBytes", float64(containerMetric.GetDiskBytes()), eventTime, labels,
+			),
+			s.buildTimeSeriesRequest(
+				"todo", "memoryBytes", float64(containerMetric.GetMemoryBytes()), eventTime, labels,
+			),
+			s.buildTimeSeriesRequest(
+				"todo", "memoryBytesQuota", float64(containerMetric.GetMemoryBytesQuota()), eventTime, labels,
+			),
 		}, nil
 	case events.Envelope_CounterEvent:
 		counterEvent := envelope.GetCounterEvent()
-		return []*Metric{{
-			Name:      counterEvent.GetName(),
-			Value:     float64(counterEvent.GetTotal()),
-			EventTime: eventTime,
-			Labels:    labels,
-		}}, nil
+		return []*monitoringpb.CreateTimeSeriesRequest{
+			s.buildTimeSeriesRequest(
+				"todo", counterEvent.GetName(), float64(counterEvent.GetTotal()), eventTime, labels,
+			),
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown event type: %v", envelope.EventType)
 	}

--- a/src/stackdriver-nozzle/serializer/serializer_test.go
+++ b/src/stackdriver-nozzle/serializer/serializer_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Serializer", func() {
 			diskBytes := uint64(164634624)
 			memoryBytes := uint64(16601088)
 			memoryBytesQuota := uint64(33554432)
+			timeStamp := int64(123)
 			applicationId := "ee2aa52e-3c8a-4851-b505-0cb9fe24806e"
 
 			metricType := events.Envelope_ContainerMetric
@@ -111,6 +112,7 @@ var _ = Describe("Serializer", func() {
 			envelope := &events.Envelope{
 				EventType:       &metricType,
 				ContainerMetric: &containerMetric,
+				Timestamp:       &timeStamp,
 			}
 
 			labels := map[string]string{
@@ -122,18 +124,19 @@ var _ = Describe("Serializer", func() {
 
 			Expect(metrics).To(HaveLen(6))
 
-			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytesQuota", float64(1073741824), labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"instanceIndex", float64(0), labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"cpuPercentage", 0.061651273460637, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytes", float64(164634624), labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytes", float64(16601088), labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytesQuota", float64(33554432), labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytesQuota", float64(1073741824), 123, labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"instanceIndex", float64(0), 123, labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"cpuPercentage", 0.061651273460637, 123, labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytes", float64(164634624), 123, labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytes", float64(16601088), 123, labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytesQuota", float64(33554432), 123, labels}))
 		})
 
 		It("creates metric for CounterEvent", func() {
 			eventType := events.Envelope_CounterEvent
 			name := "counterName"
 			total := uint64(123456)
+			eventTime := int64(123)
 
 			event := events.CounterEvent{
 				Name:  &name,
@@ -142,6 +145,7 @@ var _ = Describe("Serializer", func() {
 			envelope := &events.Envelope{
 				EventType:    &eventType,
 				CounterEvent: &event,
+				Timestamp:    &eventTime,
 			}
 
 			labels := map[string]string{
@@ -150,7 +154,7 @@ var _ = Describe("Serializer", func() {
 
 			metrics := subject.GetMetrics(envelope)
 			Expect(metrics).To(HaveLen(1))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), labels}))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), eventTime, labels}))
 		})
 	})
 

--- a/src/stackdriver-nozzle/serializer/serializer_test.go
+++ b/src/stackdriver-nozzle/serializer/serializer_test.go
@@ -47,6 +47,8 @@ var _ = Describe("Serializer", func() {
 
 		log := subject.GetLog(envelope)
 
+		Expect(log).ToNot(BeNil())
+
 		labels := log.Labels
 		Expect(labels).To(Equal(map[string]string{
 			"origin":     origin,
@@ -123,17 +125,106 @@ var _ = Describe("Serializer", func() {
 				"applicationId": applicationId,
 			}
 
-			metrics, err := subject.GetMetrics(envelope)
+			requests, err := subject.GetMetrics(envelope)
 			Expect(err).To(BeNil())
 
-			Expect(metrics).To(HaveLen(6))
+			Expect(requests).To(HaveLen(6))
 
-			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytesQuota", float64(1073741824), 123, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"instanceIndex", float64(0), 123, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"cpuPercentage", 0.061651273460637, 123, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"diskBytes", float64(164634624), 123, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytes", float64(16601088), 123, labels}))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytesQuota", float64(33554432), 123, labels}))
+			Context("diskBytesQuota", func() {
+				request := requests[0]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/diskBytesQuota"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(1073741824)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
+
+			Context("instanceIndex", func() {
+				request := requests[1]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/instanceIndex"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(0)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
+
+			Context("cpuPercentage", func() {
+				request := requests[2]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/cpuPercentage"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(0.061651273460637)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
+
+			Context("diskBytes", func() {
+				request := requests[3]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/diskBytes"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(164634624)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
+
+			Context("memoryBytes", func() {
+				request := requests[4]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/memoryBytes"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(16601088)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
+
+			Context("memoryBytesQuota", func() {
+				request := requests[5]
+				timeSeries := request.TimeSeries
+				Expect(timeSeries).To(HaveLen(1))
+
+				metric := timeSeries[0].Metric
+				Expect(metric.Type).To(Equal("custom.googleapis.com/memoryBytesQuota"))
+				Expect(metric.GetLabels()).To(Equal(labels))
+
+				points := timeSeries[0].Points
+				Expect(points).To(HaveLen(1))
+				Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(33554432)))
+				Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(int64(123)))
+				Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(int64(123)))
+			})
 		})
 
 		It("creates metric for CounterEvent", func() {
@@ -156,36 +247,61 @@ var _ = Describe("Serializer", func() {
 				"eventType": "CounterEvent",
 			}
 
-			metrics, err := subject.GetMetrics(envelope)
+			requests, err := subject.GetMetrics(envelope)
 			Expect(err).To(BeNil())
-			Expect(metrics).To(HaveLen(1))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), eventTime, labels}))
+			Expect(requests).To(HaveLen(1))
+
+			request := requests[0]
+			timeSeries := request.TimeSeries
+			Expect(timeSeries).To(HaveLen(1))
+
+			metric := timeSeries[0].Metric
+			Expect(metric.Type).To(Equal("custom.googleapis.com/counterName"))
+			Expect(metric.GetLabels()).To(Equal(labels))
+
+			points := timeSeries[0].Points
+			Expect(points).To(HaveLen(1))
+			Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(123456)))
+			Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(eventTime))
+			Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(eventTime))
 		})
 
-		It("creates metric for CounterEvent", func() {
-			eventType := events.Envelope_CounterEvent
-			name := "counterName"
-			total := uint64(123456)
+		It("creates metric for ValueMetric", func() {
+			eventType := events.Envelope_ValueMetric
+			name := "valueMetricEvent"
+			value := float64(123456)
 			eventTime := int64(123)
 
-			event := events.CounterEvent{
+			event := events.ValueMetric{
 				Name:  &name,
-				Total: &total,
+				Value: &value,
 			}
 			envelope := &events.Envelope{
-				EventType:    &eventType,
-				CounterEvent: &event,
-				Timestamp:    &eventTime,
+				EventType:   &eventType,
+				ValueMetric: &event,
+				Timestamp:   &eventTime,
 			}
 
 			labels := map[string]string{
-				"eventType": "CounterEvent",
+				"eventType": "ValueMetric",
 			}
 
-			metrics, err := subject.GetMetrics(envelope)
+			requests, err := subject.GetMetrics(envelope)
 			Expect(err).To(BeNil())
-			Expect(metrics).To(HaveLen(1))
-			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), eventTime, labels}))
+			Expect(requests).To(HaveLen(1))
+			request := requests[0]
+			timeSeries := request.TimeSeries
+			Expect(timeSeries).To(HaveLen(1))
+
+			metric := timeSeries[0].Metric
+			Expect(metric.Type).To(Equal("custom.googleapis.com/valueMetricEvent"))
+			Expect(metric.GetLabels()).To(Equal(labels))
+
+			points := timeSeries[0].Points
+			Expect(points).To(HaveLen(1))
+			Expect(points[0].Value.GetDoubleValue()).To(Equal(float64(123456)))
+			Expect(points[0].GetInterval().GetEndTime().Seconds).To(Equal(eventTime))
+			Expect(points[0].GetInterval().GetStartTime().Seconds).To(Equal(eventTime))
 		})
 
 		It("returns error when envelope contains unhandled event type", func() {
@@ -195,6 +311,33 @@ var _ = Describe("Serializer", func() {
 			}
 			_, err := subject.GetMetrics(envelope)
 			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("GetLog", func() {
+		It("should return the correct payload", func() {
+			eventType := events.Envelope_HttpStartStop
+			uri := "some/uri"
+			httpStartStop := events.HttpStartStop{
+				Uri: &uri,
+			}
+
+			envelope := &events.Envelope{
+				EventType:     &eventType,
+				HttpStartStop: &httpStartStop,
+			}
+
+			log := subject.GetLog(envelope)
+
+			Expect(log).ToNot(BeNil())
+
+			labels := log.Labels
+			payload := log.Payload
+			Expect(labels).To(Equal(map[string]string{
+				"eventType": eventType.String(),
+			}))
+
+			Expect(payload).To(Equal(envelope))
 		})
 	})
 
@@ -316,9 +459,15 @@ var _ = Describe("Serializer", func() {
 				Expect(metrics).To(HaveLen(1))
 				valueMetric := metrics[0]
 
-				labels := valueMetric.Labels
-				Expect(labels).NotTo(HaveKey("applicationId"))
+				//todo: test .Name (in a different test, just a reminder)
+				//Expect(valueMetric.Name).To(Equal("projects/"))
 
+				timeSerieses := valueMetric.TimeSeries
+				Expect(timeSerieses).To(HaveLen(1))
+
+				timeSeries := timeSerieses[0]
+				metric := timeSeries.GetMetric()
+				Expect(metric.GetLabels()).NotTo(HaveKey("applicationId"))
 			})
 
 			It("CounterEvent does not add app id", func() {
@@ -335,8 +484,15 @@ var _ = Describe("Serializer", func() {
 				Expect(metrics).To(HaveLen(1))
 				valueMetric := metrics[0]
 
-				labels := valueMetric.Labels
-				Expect(labels).NotTo(HaveKey("applicationId"))
+				//todo: test .Name (in a different test, just a reminder)
+				//Expect(valueMetric.Name).To(Equal("projects/"))
+
+				timeSerieses := valueMetric.TimeSeries
+				Expect(timeSerieses).To(HaveLen(1))
+
+				timeSeries := timeSerieses[0]
+				metric := timeSeries.GetMetric()
+				Expect(metric.GetLabels()).NotTo(HaveKey("applicationId"))
 			})
 
 			It("Error does not add app id", func() {
@@ -370,9 +526,12 @@ var _ = Describe("Serializer", func() {
 				Expect(err).To(BeNil())
 
 				Expect(len(metrics)).To(Not(Equal(0)))
-
 				for _, metric := range metrics {
-					labels := metric.Labels
+					timeSerieses := metric.TimeSeries
+					Expect(timeSerieses).To(HaveLen(1))
+					timeSeries := timeSerieses[0]
+					metric := timeSeries.GetMetric()
+					labels := metric.GetLabels()
 					Expect(labels["applicationId"]).To(Equal(appGuid))
 
 				}

--- a/src/stackdriver-nozzle/serializer/serializer_test.go
+++ b/src/stackdriver-nozzle/serializer/serializer_test.go
@@ -129,6 +129,29 @@ var _ = Describe("Serializer", func() {
 			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytes", float64(16601088), labels}))
 			Expect(metrics).To(ContainElement(&serializer.Metric{"memoryBytesQuota", float64(33554432), labels}))
 		})
+
+		It("creates metric for CounterEvent", func() {
+			eventType := events.Envelope_CounterEvent
+			name := "counterName"
+			total := uint64(123456)
+
+			event := events.CounterEvent{
+				Name:  &name,
+				Total: &total,
+			}
+			envelope := &events.Envelope{
+				EventType:    &eventType,
+				CounterEvent: &event,
+			}
+
+			labels := map[string]string{
+				"eventType": "CounterEvent",
+			}
+
+			metrics := subject.GetMetrics(envelope)
+			Expect(metrics).To(HaveLen(1))
+			Expect(metrics).To(ContainElement(&serializer.Metric{"counterName", float64(123456), labels}))
+		})
 	})
 
 	Context("isLog", func() {
@@ -159,7 +182,7 @@ var _ = Describe("Serializer", func() {
 			Expect(subject.IsLog(envelope)).To(BeFalse())
 		})
 
-		XIt("CounterEvent is *NOT* log", func() {
+		It("CounterEvent is *NOT* log", func() {
 			eventType := events.Envelope_CounterEvent
 
 			envelope := &events.Envelope{
@@ -253,8 +276,21 @@ var _ = Describe("Serializer", func() {
 
 			})
 
-			XIt("CounterEvent does not add app id", func() {
-				//TODO
+			It("CounterEvent does not add app id", func() {
+				eventType := events.Envelope_CounterEvent
+
+				event := events.CounterEvent{}
+				envelope := &events.Envelope{
+					EventType:    &eventType,
+					CounterEvent: &event,
+				}
+				metrics := subject.GetMetrics(envelope)
+
+				Expect(metrics).To(HaveLen(1))
+				valueMetric := metrics[0]
+
+				labels := valueMetric.Labels
+				Expect(labels).NotTo(HaveKey("applicationId"))
 			})
 
 			It("Error does not add app id", func() {


### PR DESCRIPTION
We used to use the current time when sending metric events to SD.
We will now use the timestamp in the envelope. Note that we still assume GAUGE type so start and end time of the event is the same. 