### PR TITLE
Concourse uploads and deploys nozzle release

### DIFF
--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -9,6 +9,12 @@ service_account: {{service_account}}
 service_account_key_json: |
   {{service_account_key_json}}
 
+# BOSH and Cloud Foundry
+bosh_director_address: {{bosh_director_address}} # IP address of BOSH director
+bosh_user:             {{bosh_user}} # Bosh admin username
+bosh_password:         {{bosh_password} # Bosh password
+cf_deployment_name:    {{cf_deployment_name}} # Name of CF deployment to update
+
 # GitHub
 github_deployment_key_bosh_google_cpi_release: | # GitHub deployment key for release artifacts
 github_pr_access_token: # An access token with repo:status access, used to test PRs

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,6 +4,7 @@ groups:
     jobs:
       - test-unit
       - build-candidate
+      - deploy-candidate
 
 jobs:
   - name: test-unit
@@ -33,6 +34,22 @@ jobs:
 
       - put: gcp-tools-release-artifacts-sha1
         params: {file: candidate/*.tgz.sha1}
+
+  - name: deploy-candidate
+    serial: true
+    plan:
+      - aggregate:
+        - {trigger: true, passed: [build-candidate],  get: gcp-tools-release,             resource: gcp-tools-release-in}
+        - {trigger: true, passed: [build-candidate],  get: gcp-tools-release-artifacts,   resource: gcp-tools-release-artifacts}
+
+      - task: build-release
+        file: gcp-tools-release/ci/tasks/deploy-candidate.yml
+        config:
+          params:
+            bosh_director_address:                 {{bosh_director_address}}
+            bosh_user:                             {{bosh_user}}
+            bosh_password:                         {{bosh_password}}
+            cf_deployment_name:                    {{cf_deployment_name}}
 
 resources:
   - name: gcp-tools-release-in

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+source gcp-tools-release/ci/tasks/utils.sh
+source /etc/profile.d/chruby-with-ruby-2.1.2.sh
+
+check_param bosh_director_address
+check_param bosh_user
+check_param bosh_password
+check_param cf_deployment_name
+
+echo "Using BOSH CLI version..."
+bosh version
+
+echo "Targeting BOSH director..."
+bosh -n target ${bosh_director_address}
+bosh login ${bosh_user} ${bosh_password}
+
+echo "Uploading nozzle release..."
+bosh upload release gcp-tools-release-artifacts/*.tgz
+
+echo "Downloading existing Cloud Foundry manifest"
+bosh download manifest ${cf_deployment_name} > cloudfoundry.yml
+bosh deployment cloudfoundry.yml
+bosh -n deploy

--- a/ci/tasks/deploy-candidate.yml
+++ b/ci/tasks/deploy-candidate.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/gce-cpi-release
+    tag: v2
+inputs:
+  - name: gcp-tools-release
+  - name: gcp-tools-release-artifacts
+run:
+  path: gcp-tools-release/ci/tasks/deploy-candidate.sh
+params:
+  bosh_director_address: replace-me
+  bosh_user:             replace-me
+  bosh_password:         replace-me
+  cf_deployment_name:    replace-me

--- a/ci/tasks/unit-tests.yml
+++ b/ci/tasks/unit-tests.yml
@@ -7,7 +7,5 @@ image_resource:
     tag: v2
 inputs:
   - name: gcp-tools-release
-outputs:
-  - name: candidate
 run:
   path: gcp-tools-release/ci/tasks/unit-tests.sh


### PR DESCRIPTION
This change adds a Concourse task to upload the latest nozzle release and re-deploy the CloudFoundry deployment that uses it.