### PR TITLE
Fix stackdriver-nozzle job

### DIFF
--- a/jobs/stackdriver-nozzle/spec
+++ b/jobs/stackdriver-nozzle/spec
@@ -5,6 +5,7 @@ templates:
 
 packages:
   - stackdriver-nozzle
+  - common
 
 properties:
   firehose.api_endpoint:

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -28,7 +28,7 @@ case $1 in
 
     echo $$ > $PIDFILE
 
-    exec chpst -u vcap:vcap /var/vcap/packages/stackdriver-nozzle/bin/stackdriver-nozzle \
+    exec /var/vcap/packages/stackdriver-nozzle/bin/stackdriver-nozzle \
       >>$LOG_DIR/stackdriver-nozzle.stdout.log \
       2>>$LOG_DIR/stackdriver-nozzle.stderr.log
 

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -14,6 +14,7 @@ case $1 in
 
     mkdir -p $RUN_DIR
     chown -R vcap:vcap $RUN_DIR
+    chown -R vcap:vcap .
 
     mkdir -p $LOG_DIR
     chown -R vcap:vcap $LOG_DIR
@@ -28,7 +29,7 @@ case $1 in
 
     echo $$ > $PIDFILE
 
-    exec /var/vcap/packages/stackdriver-nozzle/bin/stackdriver-nozzle \
+    exec chpst -u vcap:vcap /var/vcap/packages/stackdriver-nozzle/bin/stackdriver-nozzle \
       >>$LOG_DIR/stackdriver-nozzle.stdout.log \
       2>>$LOG_DIR/stackdriver-nozzle.stderr.log
 

--- a/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
+++ b/jobs/stackdriver-nozzle/templates/stackdriver-nozzle-ctl.erb
@@ -4,6 +4,8 @@ RUN_DIR=/var/vcap/sys/run/stackdriver-nozzle
 LOG_DIR=/var/vcap/sys/log/stackdriver-nozzle
 PIDFILE=$RUN_DIR/stackdriver-nozzle.pid
 
+source /var/vcap/packages/common/utils.sh
+
 case $1 in
 
   start)

--- a/packages/common/packaging
+++ b/packages/common/packaging
@@ -1,0 +1,3 @@
+set -e
+
+cp -a common/* ${BOSH_INSTALL_TARGET}

--- a/packages/common/spec
+++ b/packages/common/spec
@@ -1,0 +1,4 @@
+---
+name: common
+files:
+- common/utils.sh


### PR DESCRIPTION
These commits include the dependency for the `pid_guard` function. They also run the `stackdriver-nozzle` process as the default user. Otherwise, the `vcap` user is unable to create the boltdb file required to run.