### PR TITLE
Use an SSH tunnel to connect to BOSH director

### DIFF
--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -10,6 +10,9 @@ service_account_key_json: |
   {{service_account_key_json}}
 
 # BOSH and Cloud Foundry
+ssh_bastion_address:      {{ssh_bastion_name}} # Instance name of a VM with public SSH and access to the BOSH director
+ssh_user:              {{ssh_user}} # The SSH user that can connecto to the bastion
+ssh_key: {{ssh_key}} # The SSH key for ssh_user
 bosh_director_address: {{bosh_director_address}} # IP address of BOSH director
 bosh_user:             {{bosh_user}} # Bosh admin username
 bosh_password:         {{bosh_password} # Bosh password

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -16,6 +16,11 @@ RUN curl -sSL https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-am
 ENV GOROOT /usr/local/go
 ENV PATH $PATH:$GOROOT/bin
 
+# Install Google Cloud SDK
+ENV GCLOUD_SDK_VERSION 129.0.0
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_SDK_VERSION}-linux-x86_64.tar.gz | tar -v -C /usr/local -xz
+ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
+
 # Instal chruby
 RUN mkdir /tmp/chruby && \
     cd /tmp && \
@@ -40,3 +45,6 @@ RUN ruby-install ruby 2.1.2 && \
 
 # Install Bundler and BOSH CLI
 RUN /bin/bash -l -c "gem install bundler bosh_cli --no-ri --no-rdoc"
+
+# Install gcloud deps
+RUN apt-get install -y python python-pip libyaml-dev libpython-dev; apt-get clean

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,9 @@ jobs:
         file: gcp-tools-release/ci/tasks/deploy-candidate.yml
         config:
           params:
+            ssh_bastion_address     : {{ssh_bastion_address}}
+            ssh_user: {{ssh_user}}
+            ssh_key: {{ssh_key}}
             bosh_director_address: {{bosh_director_address}}
             bosh_user: {{bosh_user}}
             bosh_password: {{bosh_password}}
@@ -56,6 +59,7 @@ jobs:
             nozzle_user: {{nozzle_user}}
             nozzle_password: {{nozzle_password}}
             vip_ip: {{vip_ip}}
+            service_account_key_json: {{service_account_key_json}}
 
 resources:
   - name: gcp-tools-release-in

--- a/ci/tasks/build-candidate.yml
+++ b/ci/tasks/build-candidate.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: lambr/gcp-tools
-    tag: v1
+    tag: v3
 inputs:
   - name: gcp-tools-release
   - name: version-semver

--- a/ci/tasks/deploy-candidate.sh
+++ b/ci/tasks/deploy-candidate.sh
@@ -17,18 +17,40 @@ check_param nozzle_password
 
 # Google network settings
 check_param google_zone
+check_param google_region
 check_param network
 check_param private_subnetwork
 
 # Google service account settings
 check_param project_id
 check_param cf_service_account
+check_param service_account_key_json
+check_param ssh_bastion_name
+check_param ssh_user
+check_param ssh_key
+
+echo "Creating google json key..."
+mkdir -p $HOME/.config/gcloud/
+echo "${service_account_key_json}" > $HOME/.config/gcloud/application_default_credentials.json
+
+echo "Configuring google account..."
+gcloud auth activate-service-account --key-file $HOME/.config/gcloud/application_default_credentials.json
+gcloud config set project ${project_id}
+gcloud config set compute/region ${google_region}
+gcloud config set compute/zone ${google_zone}
+
+echo "Configuring SSH"
+echo -e "${ssh_key}" > /tmp/${ssh_user}.key
+chmod 700 /tmp/${ssh_user}.key
+
+echo "Connecting to SSH bastion..."
+ssh bosh@${ssh_bastion_address} -i /tmp/${ssh_user}.key -o StrictHostKeyChecking=no -L 25555:${bosh_director_address}:25555 -nNT &
 
 echo "Using BOSH CLI version..."
 bosh version
 
 echo "Targeting BOSH director..."
-bosh -n target ${bosh_director_address}
+bosh -n target localhost
 bosh login ${bosh_user} ${bosh_password}
 director_uuid=$(bosh status --uuid)
 

--- a/ci/tasks/deploy-candidate.yml
+++ b/ci/tasks/deploy-candidate.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: lambr/gcp-tools
-    tag: v1
+    tag: v3
 inputs:
   - name: gcp-tools-release
   - name: gcp-tools-release-artifacts
@@ -16,6 +16,7 @@ params:
   bosh_user:             replace-me
   bosh_password:         replace-me
   cf_deployment_name:    replace-me
+
   # CF settings
   vip_ip:          replace me
   common_password: replace me
@@ -28,5 +29,11 @@ params:
   private_subnetwork: replace me
 
   # Google service account settings
-  project_id:              replace me
-  cf_service_account_user: replace me
+  project_id:               replace me
+  cf_service_account:       replace me
+  service_account_key_json: replace me
+
+  ## SSH
+  ssh_bastion_address: replace me
+  ssh_user:         replace me
+  ssh_key:          replace me

--- a/ci/tasks/unit-tests.yml
+++ b/ci/tasks/unit-tests.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: lambr/gcp-tools
-    tag: v1
+    tag: v3
 inputs:
   - name: gcp-tools-release
 run:


### PR DESCRIPTION
This change uses an SSH tunnel to communicate with a BOSH director via its private IP address.