### PR TITLE
Remove ip and deployment from labels

### DIFF
--- a/src/stackdriver-nozzle/nozzle/label_maker.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker.go
@@ -29,10 +29,6 @@ func (lm *labelMaker) Build(envelope *events.Envelope) map[string]string {
 		labels["eventType"] = envelope.GetEventType().String()
 	}
 
-	if envelope.Deployment != nil {
-		labels["deployment"] = envelope.GetDeployment()
-	}
-
 	if envelope.Job != nil {
 		labels["job"] = envelope.GetJob()
 	}
@@ -41,9 +37,6 @@ func (lm *labelMaker) Build(envelope *events.Envelope) map[string]string {
 		labels["index"] = envelope.GetIndex()
 	}
 
-	if envelope.Ip != nil {
-		labels["ip"] = envelope.GetIp()
-	}
 	if appId := lm.getApplicationId(envelope); appId != "" {
 		labels["applicationId"] = appId
 		lm.buildAppMetadataLabels(appId, labels, envelope)

--- a/src/stackdriver-nozzle/nozzle/label_maker_test.go
+++ b/src/stackdriver-nozzle/nozzle/label_maker_test.go
@@ -49,10 +49,8 @@ var _ = Describe("LabelMaker", func() {
 		Expect(labels).To(Equal(map[string]string{
 			"origin":     origin,
 			"eventType":  eventType.String(),
-			"deployment": deployment,
 			"job":        job,
 			"index":      index,
-			"ip":         ip,
 		}))
 	})
 


### PR DESCRIPTION
We will no longer send IP and deployment as labels since it would cause some metrics to go over 10 labels. We are always removing them because otherwise there might be a case where we are not sending the same number of labels as the existing descriptor (if we are not resolving the app metadata for example). 