### PR TITLE
Made the posting metrics call async at the buffer-level

### DIFF
--- a/src/stackdriver-nozzle/mocks/metric_adapter.go
+++ b/src/stackdriver-nozzle/mocks/metric_adapter.go
@@ -3,11 +3,15 @@ package mocks
 import "github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/stackdriver"
 
 type MetricAdapter struct {
+	PostMetricsFn   func(metrics []stackdriver.Metric) error
 	PostedMetrics   []stackdriver.Metric
 	PostMetricError error
 }
 
 func (m *MetricAdapter) PostMetrics(metrics []stackdriver.Metric) error {
+	if m.PostMetricsFn != nil {
+		return m.PostMetricsFn(metrics)
+	}
 	m.PostedMetrics = append(m.PostedMetrics, metrics...)
 	return m.PostMetricError
 }

--- a/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
+++ b/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
@@ -54,9 +54,10 @@ func (mb *metricsBuffer) addMetric(newMetric *Metric) {
 }
 
 func (mb *metricsBuffer) postMetrics(metrics []Metric) {
-	err := mb.adapter.PostMetrics(metrics)
-	if err != nil {
-		go func() { mb.errs <- err }()
-	}
-
+	go func() {
+		err := mb.adapter.PostMetrics(metrics)
+		if err != nil {
+			go func() { mb.errs <- err }()
+		}
+	}()
 }


### PR DESCRIPTION
We are doing this instead of a worker pool since it is the only call that was not yet async.