### PR TITLE
Record more info in Heartbeat + Improved Efficiency of Batching

### DIFF
--- a/src/stackdriver-nozzle/filter/filter_test.go
+++ b/src/stackdriver-nozzle/filter/filter_test.go
@@ -10,7 +10,8 @@ import (
 
 var _ = Describe("Filter", func() {
 	var (
-		fhClient *mocks.FirehoseClient
+		fhClient    *mocks.FirehoseClient
+		heartbeater *mocks.Heartbeater
 	)
 
 	BeforeEach(func() {
@@ -19,7 +20,8 @@ var _ = Describe("Filter", func() {
 
 	It("can accept an empty filter and blocks all events", func() {
 		emptyFilter := []string{}
-		f, err := filter.New(fhClient, emptyFilter)
+		heartbeater = &mocks.Heartbeater{}
+		f, err := filter.New(fhClient, emptyFilter, heartbeater)
 		Expect(err).To(BeNil())
 		Expect(f).NotTo(BeNil())
 		messages, errs := f.Connect()
@@ -41,7 +43,7 @@ var _ = Describe("Filter", func() {
 
 	It("can accept a single event to filter", func() {
 		singleFilter := []string{"Error"}
-		f, err := filter.New(fhClient, singleFilter)
+		f, err := filter.New(fhClient, singleFilter, heartbeater)
 		Expect(err).To(BeNil())
 		Expect(f).NotTo(BeNil())
 		messages, errs := f.Connect()
@@ -66,7 +68,7 @@ var _ = Describe("Filter", func() {
 
 	It("can accept multiple events to filter", func() {
 		multiFilter := []string{"Error", "LogMessage"}
-		f, err := filter.New(fhClient, multiFilter)
+		f, err := filter.New(fhClient, multiFilter, heartbeater)
 		Expect(err).To(BeNil())
 		Expect(f).NotTo(BeNil())
 		messages, errs := f.Connect()
@@ -91,13 +93,31 @@ var _ = Describe("Filter", func() {
 		)
 		Consistently(messages).ShouldNot(Receive())
 		Consistently(errs).ShouldNot(Receive())
-
 	})
 
 	It("rejects invalid events", func() {
 		invalidFilter := []string{"Error", "FakeEvent111"}
-		f, err := filter.New(fhClient, invalidFilter)
+		f, err := filter.New(fhClient, invalidFilter, heartbeater)
 		Expect(err).NotTo(BeNil())
 		Expect(f).To(BeNil())
+	})
+
+	It("increments the heartbeater", func() {
+		fhClient.SendEvents(
+			events.Envelope_HttpStart,
+			events.Envelope_HttpStop,
+			events.Envelope_HttpStartStop,
+		)
+
+		Expect(heartbeater.GetCounter()).To(Equal(3))
+
+		fhClient.SendEvents(
+			events.Envelope_LogMessage,
+			events.Envelope_ValueMetric,
+			events.Envelope_CounterEvent,
+			events.Envelope_ContainerMetric,
+		)
+
+		Expect(heartbeater.GetCounter()).To(Equal(7))
 	})
 })

--- a/src/stackdriver-nozzle/filter/filter_test.go
+++ b/src/stackdriver-nozzle/filter/filter_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Filter", func() {
 
 	BeforeEach(func() {
 		fhClient = mocks.NewFirehoseClient()
-		heartbeater = mocks.NewHeartbeater()
+		heartbeater = mocks.New()
 	})
 
 	It("can accept an empty filter and blocks all events", func() {

--- a/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Heartbeat", func() {
+var _ = Describe("Heartbeater", func() {
 	var (
 		subject heartbeat.Heartbeater
 		logger  *mocks.MockLogger
@@ -22,7 +22,7 @@ var _ = Describe("Heartbeat", func() {
 		logger = &mocks.MockLogger{}
 		trigger = make(chan time.Time)
 
-		subject = heartbeat.NewHeartbeat(logger, trigger)
+		subject = heartbeat.NewHeartbeater(logger, trigger)
 		subject.Start()
 	})
 
@@ -33,7 +33,7 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "heartbeat",
+			Action: "heartbeater",
 			Datas: []lager.Data{
 				{"counters": map[string]uint{}},
 			},
@@ -51,14 +51,14 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "heartbeat",
+			Action: "heartbeater",
 			Datas: []lager.Data{
 				{"counters": map[string]uint{"foo": 10}},
 			},
 		}))
 	})
 
-	It("should reset the heartbeat on triggers", func() {
+	It("should reset the heartbeater on triggers", func() {
 		for i := 0; i < 10; i++ {
 			subject.Increment("foo")
 		}
@@ -75,7 +75,7 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "heartbeat",
+			Action: "heartbeater",
 			Datas: []lager.Data{
 				{"counters": map[string]uint{"foo": 5}},
 			},
@@ -92,7 +92,7 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "heartbeat",
+			Action: "heartbeater",
 			Datas: []lager.Data{
 				{"counters": map[string]uint{"foo": 5}},
 			},
@@ -101,8 +101,8 @@ var _ = Describe("Heartbeat", func() {
 		subject.Increment("foo")
 		Expect(logger.LastLog()).To(Equal(mocks.Log{
 			Level:  lager.ERROR,
-			Action: "heartbeat",
-			Err:    errors.New("attempted to increment counter without starting heartbeat"),
+			Action: "heartbeater",
+			Err:    errors.New("attempted to increment counter without starting heartbeater"),
 		}))
 	})
 

--- a/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
+++ b/src/stackdriver-nozzle/heartbeat/heartbeater_test.go
@@ -33,16 +33,16 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "counter",
+			Action: "heartbeat",
 			Datas: []lager.Data{
-				{"eventCount": 0},
+				{"counters": map[string]uint{}},
 			},
 		}))
 	})
 
 	It("should count events", func() {
 		for i := 0; i < 10; i++ {
-			subject.AddCounter()
+			subject.Increment("foo")
 		}
 
 		trigger <- time.Now()
@@ -51,22 +51,22 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "counter",
+			Action: "heartbeat",
 			Datas: []lager.Data{
-				{"eventCount": 10},
+				{"counters": map[string]uint{"foo": 10}},
 			},
 		}))
 	})
 
-	It("should reset the counter on triggers", func() {
+	It("should reset the heartbeat on triggers", func() {
 		for i := 0; i < 10; i++ {
-			subject.AddCounter()
+			subject.Increment("foo")
 		}
 
 		trigger <- time.Now()
 
 		for i := 0; i < 5; i++ {
-			subject.AddCounter()
+			subject.Increment("foo")
 		}
 
 		trigger <- time.Now()
@@ -75,16 +75,16 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "counter",
+			Action: "heartbeat",
 			Datas: []lager.Data{
-				{"eventCount": 5},
+				{"counters": map[string]uint{"foo": 5}},
 			},
 		}))
 	})
 
 	It("should stop counting", func() {
 		for i := 0; i < 5; i++ {
-			subject.AddCounter()
+			subject.Increment("foo")
 		}
 		subject.Stop()
 
@@ -92,17 +92,42 @@ var _ = Describe("Heartbeat", func() {
 			return logger.LastLog()
 		}).Should(Equal(mocks.Log{
 			Level:  lager.INFO,
-			Action: "counterStopped",
+			Action: "heartbeat",
 			Datas: []lager.Data{
-				{"remainingCount": 5},
+				{"counters": map[string]uint{"foo": 5}},
 			},
 		}))
 
-		subject.AddCounter()
+		subject.Increment("foo")
 		Expect(logger.LastLog()).To(Equal(mocks.Log{
 			Level:  lager.ERROR,
-			Action: "addCounter",
-			Err:    errors.New("attempted to add to counter without starting heartbeat"),
+			Action: "heartbeat",
+			Err:    errors.New("attempted to increment counter without starting heartbeat"),
+		}))
+	})
+
+	It("can count multiple events", func() {
+		for i := 0; i < 10; i++ {
+			subject.Increment("foo")
+		}
+
+		for i := 0; i < 5; i++ {
+			subject.Increment("bar")
+		}
+
+		trigger <- time.Now()
+
+		Eventually(func() mocks.Log {
+			return logger.LastLog()
+		}).Should(Equal(mocks.Log{
+			Level:  lager.INFO,
+			Action: "heartbeater",
+			Datas: []lager.Data{
+				{"counters": map[string]uint{
+					"foo": 10,
+					"bar": 5,
+				}},
+			},
 		}))
 	})
 })

--- a/src/stackdriver-nozzle/main.go
+++ b/src/stackdriver-nozzle/main.go
@@ -48,6 +48,9 @@ func newApp() *app {
 
 	logger.Info("arguments", c.ToData())
 
+	trigger := time.NewTicker(time.Duration(c.HeartbeatRate) * time.Second).C
+	heartbeater := heartbeat.NewHeartbeater(logger, trigger)
+
 	cfConfig := &cfclient.Config{
 		ApiAddress:        c.APIEndpoint,
 		Username:          c.Username,
@@ -65,26 +68,28 @@ func newApp() *app {
 	labelMaker := nozzle.NewLabelMaker(cachingClient)
 
 	return &app{
-		logger:     logger,
-		c:          c,
-		cfConfig:   cfConfig,
-		cfClient:   cfClient,
-		labelMaker: labelMaker,
+		logger:      logger,
+		c:           c,
+		cfConfig:    cfConfig,
+		cfClient:    cfClient,
+		labelMaker:  labelMaker,
+		heartbeater: heartbeater,
 	}
 }
 
 type app struct {
-	logger     lager.Logger
-	c          *config.Config
-	cfConfig   *cfclient.Config
-	cfClient   *cfclient.Client
-	labelMaker nozzle.LabelMaker
+	logger      lager.Logger
+	c           *config.Config
+	cfConfig    *cfclient.Config
+	cfClient    *cfclient.Client
+	labelMaker  nozzle.LabelMaker
+	heartbeater heartbeat.Heartbeater
 }
 
 func (a *app) newProducer() firehose.Client {
 	fhClient := firehose.NewClient(a.cfConfig, a.cfClient, a.c.SubscriptionID)
 
-	producer, err := filter.New(fhClient, strings.Split(a.c.Events, ","))
+	producer, err := filter.New(fhClient, strings.Split(a.c.Events, ","), a.heartbeater)
 	if err != nil {
 		a.logger.Fatal("filter", err)
 	}
@@ -93,13 +98,10 @@ func (a *app) newProducer() firehose.Client {
 }
 
 func (a *app) newConsumer() *nozzle.Nozzle {
-	trigger := time.NewTicker(time.Duration(a.c.HeartbeatRate) * time.Second).C
-	heartbeater := heartbeat.NewHeartbeat(a.logger, trigger)
-
 	return &nozzle.Nozzle{
 		LogSink:     a.newLogSink(),
 		MetricSink:  a.newMetricSink(),
-		Heartbeater: heartbeater,
+		Heartbeater: a.heartbeater,
 	}
 }
 

--- a/src/stackdriver-nozzle/main.go
+++ b/src/stackdriver-nozzle/main.go
@@ -125,7 +125,7 @@ func (a *app) newMetricSink() nozzle.Sink {
 		a.logger.Fatal("metricClient", err)
 	}
 
-	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient)
+	metricAdapter, err := stackdriver.NewMetricAdapter(a.c.ProjectID, metricClient, a.heartbeater)
 	if err != nil {
 		a.logger.Error("metricAdapter", err)
 	}

--- a/src/stackdriver-nozzle/main.go
+++ b/src/stackdriver-nozzle/main.go
@@ -110,6 +110,7 @@ func (a *app) newLogSink() nozzle.Sink {
 		a.c.ProjectID,
 		a.c.BatchCount,
 		time.Duration(a.c.BatchDuration)*time.Second,
+		a.heartbeater,
 	)
 	go func() {
 		err := <-logErrs

--- a/src/stackdriver-nozzle/mocks/heartbeater.go
+++ b/src/stackdriver-nozzle/mocks/heartbeater.go
@@ -1,12 +1,15 @@
 package mocks
 
+import "sync"
+
 func NewHeartbeater() *Heartbeater {
-	return &Heartbeater{false, map[string]int{}}
+	return &Heartbeater{Counters: map[string]int{}}
 }
 
 type Heartbeater struct {
 	Started  bool
 	Counters map[string]int
+	mutex    sync.Mutex
 }
 
 func (h *Heartbeater) Start() {
@@ -14,7 +17,9 @@ func (h *Heartbeater) Start() {
 }
 
 func (h *Heartbeater) Increment(name string) {
+	h.mutex.Lock()
 	h.Counters[name] += 1
+	h.mutex.Unlock()
 }
 
 func (h *Heartbeater) Stop() {

--- a/src/stackdriver-nozzle/mocks/heartbeater.go
+++ b/src/stackdriver-nozzle/mocks/heartbeater.go
@@ -1,0 +1,22 @@
+package mocks
+
+type Heartbeater struct {
+	Started bool
+	counter int
+}
+
+func (h *Heartbeater) Start() {
+	h.Started = true
+}
+
+func (h *Heartbeater) Increment(_ string) {
+	h.counter += 1
+}
+
+func (h *Heartbeater) Stop() {
+	h.Started = false
+}
+
+func (h *Heartbeater) GetCounter() int {
+	return h.counter
+}

--- a/src/stackdriver-nozzle/mocks/heartbeater.go
+++ b/src/stackdriver-nozzle/mocks/heartbeater.go
@@ -1,22 +1,22 @@
 package mocks
 
+func NewHeartbeater() *Heartbeater {
+	return &Heartbeater{false, map[string]int{}}
+}
+
 type Heartbeater struct {
-	Started bool
-	counter int
+	Started  bool
+	Counters map[string]int
 }
 
 func (h *Heartbeater) Start() {
 	h.Started = true
 }
 
-func (h *Heartbeater) Increment(_ string) {
-	h.counter += 1
+func (h *Heartbeater) Increment(name string) {
+	h.Counters[name] += 1
 }
 
 func (h *Heartbeater) Stop() {
 	h.Started = false
-}
-
-func (h *Heartbeater) GetCounter() int {
-	return h.counter
 }

--- a/src/stackdriver-nozzle/mocks/heartbeater.go
+++ b/src/stackdriver-nozzle/mocks/heartbeater.go
@@ -2,7 +2,7 @@ package mocks
 
 import "sync"
 
-func NewHeartbeater() *Heartbeater {
+func New() *Heartbeater {
 	return &Heartbeater{Counters: map[string]int{}}
 }
 

--- a/src/stackdriver-nozzle/nozzle/nozzle.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle.go
@@ -39,6 +39,7 @@ func (n *Nozzle) Start(fhClient firehose.Client) (errs chan error, fhErrs <-chan
 		for {
 			select {
 			case envelope := <-messages:
+				n.Heartbeater.Increment("nozzle.events")
 				err := n.handleEvent(envelope)
 				if err != nil {
 					errs <- err
@@ -65,7 +66,6 @@ func (n *Nozzle) handleEvent(envelope *events.Envelope) error {
 		handler = n.MetricSink
 	}
 
-	n.Heartbeater.AddCounter()
 	return handler.Receive(envelope)
 }
 

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Nozzle", func() {
 		firehose = mocks.NewFirehoseClient()
 		logSink = &mocks.Sink{}
 		metricSink = &mocks.Sink{}
-		heartbeater = &mocks.Heartbeater{}
+		heartbeater = mocks.NewHeartbeater()
 
 		subject = nozzle.Nozzle{
 			LogSink:     logSink,
@@ -46,7 +46,9 @@ var _ = Describe("Nozzle", func() {
 			firehose.Messages <- &event
 		}
 
-		Eventually(heartbeater.GetCounter).Should(Equal(len(events.Envelope_EventType_value)))
+		Eventually(func() int {
+			return heartbeater.Counters["nozzle.events"]
+		}).Should(Equal(len(events.Envelope_EventType_value)))
 	})
 
 	It("stops the heartbeater", func() {

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Nozzle", func() {
 		firehose = mocks.NewFirehoseClient()
 		logSink = &mocks.Sink{}
 		metricSink = &mocks.Sink{}
-		heartbeater = mocks.NewHeartbeater()
+		heartbeater = mocks.New()
 
 		subject = nozzle.Nozzle{
 			LogSink:     logSink,

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Nozzle", func() {
 		firehose    *mocks.FirehoseClient
 		logSink     *mocks.Sink
 		metricSink  *mocks.Sink
-		heartbeater *mockHeartbeater
+		heartbeater *mocks.Heartbeater
 		errs        chan error
 		fhErrs      <-chan error
 	)
@@ -25,7 +25,7 @@ var _ = Describe("Nozzle", func() {
 		firehose = mocks.NewFirehoseClient()
 		logSink = &mocks.Sink{}
 		metricSink = &mocks.Sink{}
-		heartbeater = &mockHeartbeater{}
+		heartbeater = &mocks.Heartbeater{}
 
 		subject = nozzle.Nozzle{
 			LogSink:     logSink,
@@ -36,7 +36,7 @@ var _ = Describe("Nozzle", func() {
 	})
 
 	It("starts the heartbeater", func() {
-		Expect(heartbeater.started).To(Equal(true))
+		Expect(heartbeater.Started).To(Equal(true))
 	})
 
 	It("updates the heartbeater", func() {
@@ -46,12 +46,12 @@ var _ = Describe("Nozzle", func() {
 			firehose.Messages <- &event
 		}
 
-		Eventually(heartbeater.getCounter).Should(Equal(len(events.Envelope_EventType_value)))
+		Eventually(heartbeater.GetCounter).Should(Equal(len(events.Envelope_EventType_value)))
 	})
 
 	It("stops the heartbeater", func() {
 		subject.Stop()
-		Expect(heartbeater.started).To(Equal(false))
+		Expect(heartbeater.Started).To(Equal(false))
 	})
 
 	It("does not receive errors", func() {
@@ -140,24 +140,3 @@ var _ = Describe("Nozzle", func() {
 		Eventually(fhErrs).Should(Receive(Equal(err)))
 	})
 })
-
-type mockHeartbeater struct {
-	started bool
-	counter int
-}
-
-func (mh *mockHeartbeater) Start() {
-	mh.started = true
-}
-
-func (mh *mockHeartbeater) Increment(_ string) {
-	mh.counter += 1
-}
-
-func (mh *mockHeartbeater) Stop() {
-	mh.started = false
-}
-
-func (mh *mockHeartbeater) getCounter() int {
-	return mh.counter
-}

--- a/src/stackdriver-nozzle/nozzle/nozzle_test.go
+++ b/src/stackdriver-nozzle/nozzle/nozzle_test.go
@@ -150,7 +150,7 @@ func (mh *mockHeartbeater) Start() {
 	mh.started = true
 }
 
-func (mh *mockHeartbeater) AddCounter() {
+func (mh *mockHeartbeater) Increment(_ string) {
 	mh.counter += 1
 }
 

--- a/src/stackdriver-nozzle/scripts/metrics_per_batch.rb
+++ b/src/stackdriver-nozzle/scripts/metrics_per_batch.rb
@@ -1,0 +1,11 @@
+require "json"
+
+count = 0
+requests = 0
+ARGF.each_line.each do |line|
+  data = JSON.parse(line)["data"]
+  data["counters"] ||= {}
+  count += data["counters"].fetch("metrics.count", 0)
+  requests += data["counters"].fetch("metrics.requests", 0)
+  puts "#{count}/#{requests}: #{count / requests.to_f}"
+end

--- a/src/stackdriver-nozzle/scripts/metrics_stats.rb
+++ b/src/stackdriver-nozzle/scripts/metrics_stats.rb
@@ -2,10 +2,15 @@ require "json"
 
 count = 0
 requests = 0
+errors = 0
+
 ARGF.each_line.each do |line|
   data = JSON.parse(line)["data"]
   data["counters"] ||= {}
+
   count += data["counters"].fetch("metrics.count", 0)
   requests += data["counters"].fetch("metrics.requests", 0)
-  puts "#{count}/#{requests}: #{count / requests.to_f}"
+  errors += data["counters"].fetch("metrics.errors", 0)
+
+  puts "Average batch size: #{count / requests.to_f}, errors/request: #{errors / requests.to_f}"
 end

--- a/src/stackdriver-nozzle/scripts/metrics_stats.rb
+++ b/src/stackdriver-nozzle/scripts/metrics_stats.rb
@@ -1,3 +1,5 @@
+#go run main.go | ruby scripts/metrics_stats.rb
+
 require "json"
 
 count = 0

--- a/src/stackdriver-nozzle/stackdriver/log_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/log_adapter.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/logging"
+	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/heartbeat"
 	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/version"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
@@ -22,7 +23,7 @@ type Log struct {
 	Labels  map[string]string
 }
 
-func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration) (LogAdapter, <-chan error) {
+func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration, heartbeater heartbeat.Heartbeater) (LogAdapter, <-chan error) {
 	errs := make(chan error)
 	loggingClient, err := logging.NewClient(context.Background(), projectID, option.WithUserAgent(version.UserAgent))
 	if err != nil {
@@ -39,16 +40,19 @@ func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration
 		logging.DelayThreshold(batchDuration),
 	)
 
-	return &logClient{
-		sdLogger: sdLogger,
+	return &logAdapter{
+		sdLogger:    sdLogger,
+		heartBeater: heartbeater,
 	}, errs
 }
 
-type logClient struct {
-	sdLogger *logging.Logger
+type logAdapter struct {
+	sdLogger    *logging.Logger
+	heartBeater heartbeat.Heartbeater
 }
 
-func (s *logClient) PostLog(log *Log) {
+func (s *logAdapter) PostLog(log *Log) {
+	s.heartBeater.Increment("logs.count")
 	entry := logging.Entry{
 		Payload: log.Payload,
 		Labels:  log.Labels,

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -3,10 +3,10 @@ package stackdriver
 import (
 	"fmt"
 	"path"
+	"sync"
 	"time"
 
-	"sync"
-
+	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/heartbeat"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/pkg/errors"
 	labelpb "google.golang.org/genproto/googleapis/api/label"
@@ -31,14 +31,16 @@ type metricAdapter struct {
 	client                MetricClient
 	descriptors           map[string]struct{}
 	createDescriptorMutex *sync.Mutex
+	heartbeater           heartbeat.Heartbeater
 }
 
-func NewMetricAdapter(projectID string, client MetricClient) (MetricAdapter, error) {
+func NewMetricAdapter(projectID string, client MetricClient, heartbeater heartbeat.Heartbeater) (MetricAdapter, error) {
 	ma := &metricAdapter{
 		projectID:             projectID,
 		client:                client,
 		createDescriptorMutex: &sync.Mutex{},
 		descriptors:           map[string]struct{}{},
+		heartbeater:           heartbeater,
 	}
 
 	err := ma.fetchMetricDescriptorNames()
@@ -50,6 +52,8 @@ func (ma *metricAdapter) PostMetrics(metrics []Metric) error {
 	var timeSerieses []*monitoringpb.TimeSeries
 
 	for _, metric := range metrics {
+		ma.heartbeater.Increment("metrics.count")
+
 		err := ma.ensureMetricDescriptor(metric)
 		if err != nil {
 			return err
@@ -71,6 +75,7 @@ func (ma *metricAdapter) PostMetrics(metrics []Metric) error {
 		TimeSeries: timeSerieses,
 	}
 
+	ma.heartbeater.Increment("metrics.requests")
 	err := ma.client.Post(request)
 	err = errors.Wrapf(err, "Request: %+v", request)
 	return err

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter.go
@@ -77,6 +77,9 @@ func (ma *metricAdapter) PostMetrics(metrics []Metric) error {
 
 	ma.heartbeater.Increment("metrics.requests")
 	err := ma.client.Post(request)
+	if err != nil {
+		ma.heartbeater.Increment("metrics.errors")
+	}
 	err = errors.Wrapf(err, "Request: %+v", request)
 	return err
 }

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -1,9 +1,10 @@
 package stackdriver_test
 
 import (
+	"errors"
 	"time"
 
-	"errors"
+	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/mocks"
 	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/stackdriver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,13 +15,15 @@ import (
 
 var _ = Describe("MetricAdapter", func() {
 	var (
-		subject stackdriver.MetricAdapter
-		client  *mockClient
+		subject     stackdriver.MetricAdapter
+		client      *mockClient
+		heartbeater *mocks.Heartbeater
 	)
 
 	BeforeEach(func() {
 		client = &mockClient{}
-		subject, _ = stackdriver.NewMetricAdapter("my-awesome-project", client)
+		heartbeater = mocks.NewHeartbeater()
+		subject, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, heartbeater)
 	})
 
 	It("takes metrics and posts a time series", func() {
@@ -164,9 +167,34 @@ var _ = Describe("MetricAdapter", func() {
 	It("returns the adapter even if we fail to list the metric descriptors", func() {
 		expectedErr := errors.New("fail")
 		client.listErr = expectedErr
-		subject, err := stackdriver.NewMetricAdapter("my-awesome-project", client)
+		subject, err := stackdriver.NewMetricAdapter("my-awesome-project", client, heartbeater)
 		Expect(subject).To(Not(BeNil()))
 		Expect(err).To(Equal(expectedErr))
+	})
+
+	It("increments metrics counters", func() {
+		metrics := []stackdriver.Metric{
+			{
+				Name: "metricWithUnit",
+				Unit: "{foobar}",
+			},
+			{
+				Name: "metricWithUnitToo",
+				Unit: "{barfoo}",
+			},
+			{
+				Name: "anExistingMetric",
+				Unit: "{lalala}",
+			},
+		}
+
+		subject.PostMetrics(metrics)
+		Expect(heartbeater.Counters["metrics.count"]).To(Equal(3))
+		Expect(heartbeater.Counters["metrics.requests"]).To(Equal(1))
+
+		subject.PostMetrics(metrics)
+		Expect(heartbeater.Counters["metrics.count"]).To(Equal(6))
+		Expect(heartbeater.Counters["metrics.requests"]).To(Equal(2))
 	})
 })
 

--- a/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
+++ b/src/stackdriver-nozzle/stackdriver/metric_adapter_test.go
@@ -22,7 +22,7 @@ var _ = Describe("MetricAdapter", func() {
 
 	BeforeEach(func() {
 		client = &mockClient{}
-		heartbeater = mocks.NewHeartbeater()
+		heartbeater = mocks.New()
 		subject, _ = stackdriver.NewMetricAdapter("my-awesome-project", client, heartbeater)
 	})
 

--- a/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
+++ b/src/stackdriver-nozzle/stackdriver/metrics_buffer.go
@@ -46,10 +46,11 @@ func (mb *metricsBuffer) addMetric(newMetric *Metric) {
 		/*
 			Stack driver API does not let us have multiple time series with the same name/label
 			in a single request. Furthermore, within each time series, we cannot have multiple points.
-			Due to this, if we encounter a metric with same name/labels, we will send it individually
-			and not buffer it (╯°□°）╯︵ ┻━┻
+			Due to this, if we encounter a metric with same name/labels, we will send the current buffer
+			and make a new buffer with the duplicate metric (╯°□°）╯︵ ┻━┻
 		*/
-		mb.postMetrics([]Metric{*newMetric})
+		mb.postMetrics(mb.metrics)
+		mb.metrics = []Metric{*newMetric}
 	}
 }
 


### PR DESCRIPTION
The heartbeat now records:
 * # Metric requests
 * # Metric Timeseries
 * # Logs
 * # Stackdriver Metric Client Errors

Instead of sending a duplicate metric individually, we will now send the current buffer of metrics and start a new one with the duplicate. 
Added a script to get statistic on our heartbeat. 