### PR TITLE
Add Severity for LogMessages and better Message Payload

### DIFF
--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -1,8 +1,9 @@
 package nozzle
 
 import (
-	"cloud.google.com/go/logging"
 	"encoding/json"
+
+	"cloud.google.com/go/logging"
 	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/stackdriver"
 	"github.com/cloudfoundry/sonde-go/events"
 )
@@ -59,6 +60,8 @@ func (ls *logSink) parseEnvelope(envelope *events.Envelope) (interface{}, loggin
 			severity = parseSeverity(logMessage.GetMessageType())
 			logMessageMap["message"] = string(logMessage.GetMessage())
 			envelopeMap["logMessage"] = logMessageMap
+			// Duplicate the message payload where stackdriver expects it
+			envelopeMap["message"] = string(logMessage.GetMessage())
 		}
 	case events.Envelope_HttpStartStop:
 		httpStartStop := envelope.GetHttpStartStop()

--- a/src/stackdriver-nozzle/nozzle/log_sink.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink.go
@@ -63,6 +63,10 @@ func (ls *logSink) parseEnvelope(envelope *events.Envelope) (interface{}, loggin
 			// Duplicate the message payload where stackdriver expects it
 			envelopeMap["message"] = string(logMessage.GetMessage())
 		}
+	case events.Envelope_Error:
+		errorMessage := envelope.GetError().GetMessage()
+		envelopeMap["message"] = errorMessage
+		severity = logging.Error
 	case events.Envelope_HttpStartStop:
 		httpStartStop := envelope.GetHttpStartStop()
 		httpStartStopMap := structToMap(httpStartStop)

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -3,6 +3,8 @@ package nozzle_test
 import (
 	"time"
 
+	"cloud.google.com/go/logging"
+
 	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/mocks"
 	"github.com/cloudfoundry-community/gcp-tools-release/src/stackdriver-nozzle/nozzle"
 	"github.com/cloudfoundry/sonde-go/events"
@@ -127,6 +129,26 @@ var _ = Describe("LogSink", func() {
 					"message":      "19400: Success: Go",
 				},
 			}))
+			Expect(postedLog.Severity).To(Equal(logging.Default))
+		})
+
+		It("has resolved severity for a LogMessage from an Error", func() {
+			eventType := events.Envelope_LogMessage
+			messageType := events.LogMessage_ERR
+
+			event := events.LogMessage{
+				MessageType: &messageType,
+			}
+			envelope := &events.Envelope{
+				EventType:  &eventType,
+				LogMessage: &event,
+			}
+
+			subject.Receive(envelope)
+
+			postedLog := logAdapter.PostedLogs[0]
+
+			Expect(postedLog.Severity).To(Equal(logging.Error))
 		})
 	})
 })

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -151,5 +151,30 @@ var _ = Describe("LogSink", func() {
 
 			Expect(postedLog.Severity).To(Equal(logging.Error))
 		})
+
+		It("has severity and message for Error event types", func() {
+			eventType := events.Envelope_Error
+			source := "cf-source"
+			code := int32(-1)
+			message := "some error message"
+			event := events.Error{
+				Source:  &source,
+				Code:    &code,
+				Message: &message,
+			}
+			envelope := &events.Envelope{
+				EventType: &eventType,
+				Error:     &event,
+			}
+
+			subject.Receive(envelope)
+
+			postedLog := logAdapter.PostedLogs[0]
+
+			payload, ok := postedLog.Payload.(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(payload["message"]).To(Equal("some error message"))
+			Expect(postedLog.Severity).To(Equal(logging.Error))
+		})
 	})
 })

--- a/src/stackdriver-nozzle/nozzle/log_sink_test.go
+++ b/src/stackdriver-nozzle/nozzle/log_sink_test.go
@@ -128,6 +128,7 @@ var _ = Describe("LogSink", func() {
 					"message_type": "OUT",
 					"message":      "19400: Success: Go",
 				},
+				"message": "19400: Success: Go",
 			}))
 			Expect(postedLog.Severity).To(Equal(logging.Default))
 		})

--- a/src/stackdriver-nozzle/stackdriver/log_adapter.go
+++ b/src/stackdriver-nozzle/stackdriver/log_adapter.go
@@ -18,8 +18,9 @@ type LogAdapter interface {
 }
 
 type Log struct {
-	Payload interface{}
-	Labels  map[string]string
+	Payload  interface{}
+	Labels   map[string]string
+	Severity logging.Severity
 }
 
 func NewLogAdapter(projectID string, batchCount int, batchDuration time.Duration) (LogAdapter, <-chan error) {
@@ -50,8 +51,9 @@ type logClient struct {
 
 func (s *logClient) PostLog(log *Log) {
 	entry := logging.Entry{
-		Payload: log.Payload,
-		Labels:  log.Labels,
+		Payload:  log.Payload,
+		Labels:   log.Labels,
+		Severity: log.Severity,
 	}
 	s.sdLogger.Log(entry)
 }


### PR DESCRIPTION
This change resolves the severity from LogMessage.MessageType. It also duplicates the message payload in a spot where Stackdriver expects it. This preserves the event object structure while making the console way more readable.
